### PR TITLE
Update the following things in config.xml to make the iTunes Store happy:

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,16 +1,16 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="io.adventurecycling.bicycletouringcompanion" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="org.adventurecycling.bicycletouringcompanion" version="1.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>BTC</name>
     <description>
         The Adventure Cycling Association inspires and empowers people to
         travel by bicycle. For cyclists who want a better experience while
-        touring, the Bicycle Touring Digital Companion (BTDC) is a targeted
+        touring, the Bicycle Touring Companion (BTC) is a targeted
         mapping and service review application that allows cyclists to obtain
         information for services, points of interest, and alerts along
         bicycle touring routes in the United States.
     </description>
     <author email="" href="">
-        Bikelomatic Complexity
+        Adventure Cycling Association
     </author>
     <content src="index.html" />
     <access origin="*" />
@@ -72,14 +72,17 @@
         <icon src="src/img/app-icons/ios/icon-50@2x.png" width="100" height="100" />
     </platform>
 
-    <plugin name="cordova-plugin-camera" spec="~2.1.0" />
+    <plugin name="cordova-plugin-camera" spec="~2.3.0">
+		<variable name="CAMERA_USAGE_DESCRIPTION" value="BTC uses your camera to add photos of points of interest." />
+		<variable name="PHOTOLIBRARY_USAGE_DESCRIPTION" value="BTC uses your photo library to add photos of points of interest." />
+    </plugin>
     <plugin name="cordova-plugin-device" spec="~1.1.1" />
     <plugin name="cordova-plugin-geolocation" spec="~2.1.0" />
-    <plugin name="cordova-plugin-network-information" spec="~1.2.0" />
     <plugin name="cordova-plugin-file" spec="~4.1.1" />
     <plugin name="cordova-plugin-file-transfer" spec="~1.5.0" />
-    <plugin name="cordova-plugin-whitelist" version="~1.3.0" />
+    <plugin name="cordova-plugin-network-information" spec="~1.2.0" />
     <plugin name="cordova-plugin-statusbar" version="~2.2.0" />
+    <plugin name="cordova-plugin-whitelist" version="~1.3.0" />
 
     <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarBackgroundColor" value="#000000" />


### PR DESCRIPTION
- Change bundle ID to org.adventurecycling.bicycletouringcompanion
- Change version number to 1.0
- Update cordova-plugin-camera to 2.3.0 so it supports the following fixes
- Add CAMERA_USAGE_DESCRIPTION which adds a privacy descriptor now required on iOS 10
- Add PHOTOLIBRARY_USAGE_DESCRIPTION which adds a privacy descriptor now required on iOS 10

Also while I'm at it:
- Fix the app name in the description
- Change the author from last year's team to Adventure Cycling Association
- Reorder plugin list to be alphabetical

https://github.com/Tour-de-Force/btc-app/issues/26