### PR TITLE
Allow track page to scroll

### DIFF
--- a/src/js/containers/download-track-page.js
+++ b/src/js/containers/download-track-page.js
@@ -34,6 +34,7 @@ class DownloadTrackPage extends Component {
   }
 
   render() {
+    const scrollStyle = {'overflow-y':'scroll'};
     const {tracks} = this.props;
 
     const downloaded = Object.keys( tracks ).reduce( ( pre, cur ) => {
@@ -76,7 +77,7 @@ class DownloadTrackPage extends Component {
 
       return (
         <Card key={ id }
-          style={ { margin: 16 } }>
+          style={ { margin: 24 } }>
           <CardMedia overlay={ <CardTitle title={ track.name }
                                  subtitle={ `${track.sizeMiB} MiB` } /> }>
             <img src='./img/usbr20.png' />
@@ -103,7 +104,9 @@ class DownloadTrackPage extends Component {
     return (
       <Page className="layout__section">
         <DeviceStorage downloaded={ downloaded } />
-        { rows }
+        <div style={scrollStyle}>
+          { rows }
+        </div>
       </Page>
       );
   }

--- a/src/js/containers/filter-page.js
+++ b/src/js/containers/filter-page.js
@@ -132,13 +132,13 @@ class FilterPage extends Component {
           <div className="form-row">
             <Checkbox label="Only Show Open Services"
               onCheck={ this.toggleOpenServices.bind( this ) }
-              style={ { marginBotton: 16 } }
+              style={ { marginBottom: 16 } }
               checked={ this.state.openServices } />
           </div>
           <div className="form-row">
             <Checkbox label="Hide Alerts"
               onCheck={ this.toggleAlert.bind( this ) }
-              style={ { marginBotton: 16 } }
+              style={ { marginBottom: 16 } }
               checked={ this.state.hideAlert } />
           </div>
           { filtersDropDowns }


### PR DESCRIPTION
- Material-ui cards will now scroll on screen so they do not get cut off
- Fixed typo on filter page (not sure it made a difference)

https://github.com/Tour-de-Force/btc-app/issues/9