### PR TITLE
Move import of MuiThemeProvider inside /*eslint-disable no-unused-vars*/ to make the linter happy.

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -5,11 +5,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router, Route, IndexRoute } from 'react-router';
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 /*eslint-enable no-unused-vars*/
 
 import ReactDOM from 'react-dom';
-
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 // The React components below are inserted by the React router
 import Main from './containers/main';


### PR DESCRIPTION
https://github.com/Tour-de-Force/btc-app/issues/43