### PR TITLE
Remove overflow-y: auto !important; from large cards.

### DIFF
--- a/src/css/point-card.css
+++ b/src/css/point-card.css
@@ -52,15 +52,13 @@
  * entire height of the screen. Also, increase the max-width so the card
  * grows a bit more on Desktop.
  *
- * Override <Card>'s overflow-y property so we can scroll if needed.
- * The card is a flexbox in view and rate mode! This is so the card's contents
- * fill the space in the card.
+ * Overriding <Card>'s overflow-y property breaks the page in WebKit.
+ * It is unnecessary as both Chrome and Safari handle scrolling correctly.
  */
 .point-card--view, .point-card--rate {
-    flex-grow: 1;
-    max-width: 750px;
-    overflow-y: auto !important;
     display: flex;
+    flex-grow: 1;
+    max-width: 750px !important;
 }
 
 /*


### PR DESCRIPTION
This property wasn't doing anything but freaking out WebKit.

Chrome and Safari both scroll properly when the card is too tall without specifying this.

https://github.com/Tour-de-Force/btc-app/issues/2