### PR TITLE
Fix tab change action to be triggered by "onActive" which is supported by Material UI.

### DIFF
--- a/src/js/containers/wizard/point-page.js
+++ b/src/js/containers/wizard/point-page.js
@@ -284,7 +284,7 @@ export default class PointPage extends Component {
     const tabs = this.getTabSet().map( tab => (
       <Tab key={ tab.value }
         value={ tab.value }
-        onTouchTap={ this.navigateToTab.bind( this, tab ) }
+        onActive={ this.navigateToTab.bind( this, tab ) }
         icon={ tab.icon } />
     ) );
 


### PR DESCRIPTION
Updating Material UI broke this behavior that I don't believe was documented as supported by that library anyway.

https://github.com/Tour-de-Force/btc-app/issues/56