### PR TITLE
Don't resize the point icon to the height of the header.

### DIFF
--- a/src/css/point-card.css
+++ b/src/css/point-card.css
@@ -101,11 +101,11 @@
 
 /*
  * SVG icon representing the type of the point. We override Material-UI's
- * height and width properties set as inline styles. This causes the icon
- * to fill the height of the card header.
+ * height and width properties set as inline styles. We set a height that
+ * looks good here.
  */
 .point-card__avatar {
-    height: 100% !important;
+    height: 36px !important;
     width: auto !important;
 }
 
@@ -113,7 +113,9 @@
  * Menu inside the point-card's header.
  */
 .point-card__icon-menu {
-    float: right;
+	position: absolute !important;
+	top: 16px;
+	right: 16px;
     height: 40px;
     width: auto;
 }

--- a/src/js/components/point-card/point-card.js
+++ b/src/js/components/point-card/point-card.js
@@ -186,7 +186,7 @@ export class PointCard extends Component {
         <CardHeader className="point-card__header"
           title={ point.name }
           subtitle={ display( point.type ) }
-          avatar={ <LocationIcon className="point-card__avatar" height="36px"/> }>
+          avatar={ <LocationIcon className="point-card__avatar"/> }>
           { this.getIconMenu() }
         </CardHeader>
         <div className="point-card__scroll">


### PR DESCRIPTION
Just keep it at 36px tall. Position the menu buttons with an absolute position
to prevent browser specific nonsense with popping to the next line when trying
to float.

https://github.com/Tour-de-Force/btc-app/issues/68
