### PR TITLE
Bump iOS deployment target to 9.0

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -30,7 +30,7 @@
     <preference name="android-minSdkVersion" value="19" />
 
     <!-- Set's iOS's minimum -->
-    <preference name="deployment-target" value="8.0" />
+    <preference name="deployment-target" value="9.0" />
 
     <platform name="android">
         <allow-intent href="market:*" />


### PR DESCRIPTION
Rebuilt Xcode project and confirmed deployment target is now iOS 9.0

https://github.com/Tour-de-Force/btc-app/issues/23
