### PR TITLE
uri validation is only done on non empty strings

### DIFF
--- a/src/js/components/wizard/wizard-page.js
+++ b/src/js/components/wizard/wizard-page.js
@@ -39,7 +39,15 @@ export class WizardPage extends Component {
   // # getPageValues
   // Pick the values for fields in `getPageFields()` for serialization;
   getPageValues() {
-    return assign( {}, pick( this.state, this.getPageFields() ) );
+    const object = assign( {}, pick( this.state, this.getPageFields() ) );
+    for (var property in object) {
+      if (object.hasOwnProperty(property)) {
+        if (object[property] === "") {
+          object[property] = undefined;
+        }
+      }
+    }
+    return object;
   }
 
   // # getPageContent


### PR DESCRIPTION
This change should fix the uri validation problem when adding or updating a service.

https://github.com/Tour-de-Force/btc-app/issues/114