### PR TITLE
Add the "retry" flag to the Pouch-Couch replication to work around occasional connection drops while replicating.

### DIFF
--- a/src/js/reducers/points.js
+++ b/src/js/reducers/points.js
@@ -281,7 +281,7 @@ export function replicatePoints() {
     const time = new Date().toISOString();
     dispatch( { type: REQUEST_REPLICATION, time } );
 
-    local.replicate.from( remote ).then( result => {
+    local.replicate.from( remote, { retry: true } ).then( result => {
       dispatch( { type: RECEIVE_REPLICATION, time: result.end_time } );
       dispatch( reloadPoints() );
     } ).catch( err => {


### PR DESCRIPTION
It keeps retrying on failure.

This flag is listed as "ideal for scenarios where the user may be flitting in and out of connectivity, such as on mobile devices" (and it helps our issue by not giving up as soon as it sees a single connection drop).

https://github.com/Tour-de-Force/btc-app/issues/150