### PR TITLE
Separate out the photos in the client from the points table

### DIFF
--- a/src/js/components/point-card/point-card.js
+++ b/src/js/components/point-card/point-card.js
@@ -201,9 +201,9 @@ static expiresOn( alert ) {
     }
 
     let coverPhotoUrl = this.props.coverPhotoUrls[this.point._id];
-    let coverUrlStyle = {};
+    let coverPhotoStyle = {};
     if ( coverPhotoUrl ) {
-      coverUrlStyle.backgroundImage = `url(${coverPhotoUrl})`;
+      coverPhotoStyle.backgroundImage = `url(${coverPhotoUrl})`;
     }
 
     return (
@@ -216,7 +216,7 @@ static expiresOn( alert ) {
         </CardHeader>
         <div className="point-card__scroll">
           <CardMedia className="point-card__media"
-            style={ coverUrlStyle } />
+            style={ coverPhotoStyle } />
           { this.getCardContent() }
         </div>
         <CardActions className="point-card__actions">

--- a/src/js/components/point-card/point-card.js
+++ b/src/js/components/point-card/point-card.js
@@ -58,18 +58,20 @@ export class PointCard extends Component {
   // method, but `loadPoint` synchronously puts some default data into
   // points[ params.id ] that we need *before* render.
   componentDidMount() {
-    const {params, points, loadPoint} = this.props;
+    const {params, points, loadPoint, getCoverPhotoURLForPointId} = this.props;
     loadPoint( params.id );
     this.point = points[ params.id ];
+    getCoverPhotoURLForPointId( params.id );
   }
 
   // # componentWillReceiveProps
   // See componentDidMount. As we are potentially getting a new id to display
   // from the router, we need to load the point for that id.
   componentWillReceiveProps( nextProps ) {
-    const {params, points, loadPoint} = nextProps;
+    const {params, points, loadPoint, getCoverPhotoURLForPointId} = nextProps;
     loadPoint( params.id );
     this.point = points[ params.id ];
+    getCoverPhotoURLForPointId( params.id );
   }
 
   // Return a function that navigates to a different page with the loaded
@@ -198,9 +200,10 @@ static expiresOn( alert ) {
         );
     }
 
+    let coverPhotoUrl = this.props.coverPhotoUrls[this.point._id];
     let coverUrlStyle = {};
-    if ( point.coverUrl ) {
-      coverUrlStyle.backgroundImage = `url(${point.coverUrl})`;
+    if ( coverPhotoUrl ) {
+      coverUrlStyle.backgroundImage = `url(${coverPhotoUrl})`;
     }
 
     return (

--- a/src/js/components/point-list.js
+++ b/src/js/components/point-list.js
@@ -3,14 +3,20 @@ import React, { Component, PropTypes } from 'react';
 import { List, ListItem, IconButton, FontIcon, Divider, Avatar } from 'material-ui';
 /*eslint-enable no-unused-vars*/
 
+import { getCoverPhotoURLForPointId } from '../reducers/points';
+
 import { display } from 'btc-models';
 
+import { connect } from 'react-redux';
+
 export class PointList extends Component {
-  componentDidMount() {
-    Object.keys(state.points.points).forEach(function(pointId) {
-      // Load all the photos in if they are not yet loaded.
-      getCoverPhotoURLForPointId(pointId);
-    });
+  componentWillReceiveProps(nextProps) {
+	if(nextProps.getCoverPhotoURLForPointId) {
+		nextProps.points.forEach(function(point) {
+		// Load all the photos in if they are not yet loaded.
+			nextProps.getCoverPhotoURLForPointId(point._id);
+		});
+	}
   }
 
   render() {
@@ -55,4 +61,11 @@ export class PointList extends Component {
   }
 }
 
-export default PointList;
+function mapStateToProps( state ) {
+  return {
+  };
+}
+
+const mapDispatchToProps = { getCoverPhotoURLForPointId };
+
+export default connect( mapStateToProps, mapDispatchToProps )( PointList );

--- a/src/js/components/point-list.js
+++ b/src/js/components/point-list.js
@@ -6,6 +6,13 @@ import { List, ListItem, IconButton, FontIcon, Divider, Avatar } from 'material-
 import { display } from 'btc-models';
 
 export class PointList extends Component {
+  componentDidMount() {
+    Object.keys(state.points.points).forEach(function(pointId) {
+      // Load all the photos in if they are not yet loaded.
+      getCoverPhotoURLForPointId(pointId);
+    });
+  }
+
   render() {
     const points = this.props.points.map( point => {
       const listProps = {};
@@ -21,8 +28,8 @@ export class PointList extends Component {
         );
       }
 
-      if ( point.coverUrl ) {
-        listProps.leftAvatar = <Avatar src={ point.coverUrl } />;
+      if ( this.props.coverPhotoUrls[point._id] ) {
+        listProps.leftAvatar = <Avatar src={ this.props.coverPhotoUrls[point._id] } />;
       }
 
       return (

--- a/src/js/components/wizard/alert-name-description.js
+++ b/src/js/components/wizard/alert-name-description.js
@@ -16,8 +16,7 @@ export class AlertNameDescription extends WizardPage {
       type: point.type,
       location: point.location,
       expiration_date: point.expiration_date,
-      description: point.description,
-      coverUrl: point.coverUrl
+      description: point.description
     } );
   }
 
@@ -39,17 +38,6 @@ export class AlertNameDescription extends WizardPage {
         value={ type }
         primaryText={ values.display } />
     ) );
-
-    const {coverUrl} = this.state;
-    let image;
-    if ( coverUrl ) {
-      image = (
-        <div>
-          <image style={ { width: '100%' } }
-            src={ coverUrl } />
-        </div>
-      );
-    }
 
     let {validationErrors} = this.props;
     if ( !validationErrors ) {
@@ -92,7 +80,6 @@ export class AlertNameDescription extends WizardPage {
           autoOk = {true}
           firstDayOfWeek ={0}
           errorText={ validationErrors[ 'expiration_date' ] ? validationErrors[ 'expiration_date' ].message : '' } />
-        { image }
       </div>
       );
   }

--- a/src/js/components/wizard/service-description.js
+++ b/src/js/components/wizard/service-description.js
@@ -13,8 +13,7 @@ export class ServiceDescription extends WizardPage {
       description: point.description,
       phone: point.phone,
       address: point.address,
-      website: point.website,
-      coverUrl: point.coverUrl
+      website: point.website
     } );
   }
 
@@ -28,24 +27,11 @@ export class ServiceDescription extends WizardPage {
       'phone',
       'address',
       'website',
-      'coverBlob',
-      'coverUrl'
+      'coverBlob'
     ];
   }
 
   getPageContent() {
-    const {coverUrl} = this.state;
-
-    let image;
-    if ( coverUrl ) {
-      image = (
-        <div>
-          <image style={ { width: '100%' } }
-            src={ coverUrl } />
-        </div>
-      );
-    }
-
     let {validationErrors} = this.props;
     if ( !validationErrors ) {
       validationErrors = {};
@@ -74,7 +60,6 @@ export class ServiceDescription extends WizardPage {
           rows={ 2 }
           rowsMax={ 4 }
           errorText={ validationErrors[ 'description' ] ? validationErrors[ 'description' ].message : '' } />
-        { image }
       </div>
       );
   }
@@ -91,7 +76,7 @@ export class ServiceDescription extends WizardPage {
       return anySet || !isEmpty( this.state[ field ] );
     }, false );
 
-    if ( anySet ) {
+    if ( anySet || this.state.coverBlob ) {
       return WizardPage.transitions.next;
     } else {
       return WizardPage.transitions.skip;

--- a/src/js/components/wizard/wizard-page.js
+++ b/src/js/components/wizard/wizard-page.js
@@ -225,7 +225,7 @@ export class WizardPage extends Component {
 
             let context = canvas.getContext('2d');
             context.drawImage(loadedCoverBlob, 0, 0, newWidth, newHeight);
-            let resizedDataUrl = canvas.toDataURL('image/png');
+            let resizedDataUrl = canvas.toDataURL('image/jpg');
 
             let resizedCoverBlob = dataURLToBlob(resizedDataUrl);
 
@@ -240,7 +240,7 @@ export class WizardPage extends Component {
     }, {
       sourceType: navigator.camera.PictureSourceType.PHOTOLIBRARY,
       destinationType: navigator.camera.DestinationType.FILE_URI,
-      encodingType: navigator.camera.EncodingType.PNG
+      encodingType: navigator.camera.EncodingType.JPG
     } );
   }
 }

--- a/src/js/components/wizard/wizard-page.js
+++ b/src/js/components/wizard/wizard-page.js
@@ -230,8 +230,7 @@ export class WizardPage extends Component {
             let resizedCoverBlob = dataURLToBlob(resizedDataUrl);
 
             resizedCoverBlob.then(coverBlob => {
-              let coverUrl = createObjectURL(coverBlob);
-              this.wizardPage.setState( { coverBlob, coverUrl } );
+              this.wizardPage.setState( { coverBlob } );
             });
           };
         } );

--- a/src/js/containers/list-page.js
+++ b/src/js/containers/list-page.js
@@ -48,6 +48,7 @@ class ListPage extends Component {
             icon={ <FilterIcon /> }
             onTouchTap={ ( ) => history.push( 'filter' ) } />
           <PointList points={ this.props.points }
+            coverPhotoUrls={ this.props.coverPhotoUrls }
             clickAction={ this.onPointClick.bind( this ) } />
         </div>
       </Page>
@@ -57,7 +58,8 @@ class ListPage extends Component {
 
 function mapStateToProps( state ) {
   return {
-    points: values( state.points.points )
+    points: values( state.points.points ),
+    coverPhotoUrls: state.points.coverPhotoUrls
   };
 }
 

--- a/src/js/containers/map-page.js
+++ b/src/js/containers/map-page.js
@@ -12,6 +12,7 @@ import { connect } from 'react-redux';
 
 import { setDrawer } from '../reducers/btc-drawer';
 import { loadPoint, flagPoint, updateService } from '../reducers/points';
+import { getCoverPhotoURLForPointId } from '../reducers/points';
 
 import history from '../history';
 
@@ -51,9 +52,9 @@ class MapPage extends Component {
   // This function will throw an error if there is more than one child.
   mapPropsOnCard() {
     if ( !this.props.children ) return;
-    const {points} = this.props;
+    const {points, coverPhotoUrls} = this.props;
 
-    const cardState = { points, heightOffset: 0 };
+    const cardState = { points, coverPhotoUrls, heightOffset: 0 };
     const cardFunctions = {
       deselectMarker: MapPage.deselectMarker,
       navigateWithId: MapPage.navigateWithId
@@ -95,7 +96,8 @@ class MapPage extends Component {
 
 function mapStateToProps( state ) {
   return {
-    points: state.points.points // PointCards are built for this marker
+    points: state.points.points, // PointCards are built for this marker
+    coverPhotoUrls: state.points.coverPhotoUrls
   };
 }
 
@@ -108,7 +110,8 @@ function mapDispatchToProps( dispatch ) {
     cardActions: bindActionCreators( {
       'loadPoint': loadPoint, // Cards load markers on componentDidMount,
       'flagPoint': flagPoint,
-      'updateService': updateService
+      'updateService': updateService,
+      'getCoverPhotoURLForPointId': getCoverPhotoURLForPointId
     }, dispatch ),
     pageActions: bindActionCreators( {
       'setDrawer': setDrawer

--- a/src/js/containers/publish-page.js
+++ b/src/js/containers/publish-page.js
@@ -65,6 +65,7 @@ class PublishPage extends Component {
         <Paper>
           <PointList instructions={ instructions }
             points={ this.props.points }
+            coverPhotoUrls={ this.props.coverPhotoUrls }
             /*buttonIcon='clear'
             buttonAction={ this.onPointRemove.bind( this ) }*/
             clickAction={ this.onPointClick.bind( this ) } />
@@ -83,7 +84,8 @@ class PublishPage extends Component {
 
 function mapStateToProps( state ) {
   return {
-    points: state.points.publish.updated.map( id => state.points.points[ id ] )
+    points: state.points.publish.updated.map( id => state.points.points[ id ] ),
+    coverPhotoUrls: state.points.coverPhotoUrls
   };
 }
 

--- a/src/js/containers/wizard/update-service-page.js
+++ b/src/js/containers/wizard/update-service-page.js
@@ -65,8 +65,6 @@ export class UpdateServicePage extends PointPage {
   }
 
   // # onFinal
-  // Before calling `updateService`, transfer our original coverUrl to the
-  // new service in case we don't have a new one to attach.
   onFinal() {
     const {updateService, params} = this.props;
     const {point, coverBlob} = this.state;
@@ -75,7 +73,6 @@ export class UpdateServicePage extends PointPage {
     service.update();
     // Keep the previous ID. We can't be changing IDs when the name changes.
     service._id = params.id;
-    service.coverUrl = point.coverUrl;
     if ( service.isValid() ) {
       updateService( service, coverBlob );
       history.push( '/' );

--- a/src/js/database.js
+++ b/src/js/database.js
@@ -28,3 +28,5 @@ export function resetDatabaseAndLocalStorageAndRefresh() {
 const {protocol, domain, port} = config.get( 'Client.couch' );
 const url = `${ protocol }://${ domain }:${ port }/points`;
 export const remote = new PouchDB( url );
+
+export const photoBaseUrl = `${ protocol }://${ domain }:${ port }/photos`;

--- a/src/js/reducers/points.js
+++ b/src/js/reducers/points.js
@@ -309,7 +309,7 @@ export function getCoverPhotoURLForPointId( pointId ) {
           });
         });
       } else {
-        let testRemoteURL = photoBaseUrl + "/" + encodeURIComponent(pointId) + "/photo.png";
+        let testRemoteURL = photoBaseUrl + "/" + encodeURIComponent(pointId) + "/coverPhoto.jpg";
 
         const request = new XMLHttpRequest();
         request.open( 'HEAD', testRemoteURL );
@@ -458,7 +458,7 @@ function buildFormData( models, unpublishedCoverPhotos ) {
 
   var convertAndAppend = function(cover){
     return base64StringToBlob(cover).then((coverPhotoBlob) => {
-      formData.append( 'covers', coverPhotoBlob, 'cover.png' );
+      formData.append( 'covers', coverPhotoBlob, 'coverPhoto.jpg' );
     });
   };
 

--- a/src/js/reducers/points.js
+++ b/src/js/reducers/points.js
@@ -11,6 +11,8 @@ import { set, unset, bindAll, cloneDeep } from 'lodash';
 
 import { blobToBase64String, base64StringToBlob } from 'blob-util';
 
+import {REHYDRATE} from 'redux-persist/constants'
+
 export const ADD_SERVICE = 'btc-app/points/ADD_SERVICE';
 export const ADD_ALERT = 'btc-app/points/ADD_ALERT';
 export const UPDATE_SERVICE = 'btc-app/points/UPDATE_SERVICE';
@@ -48,6 +50,14 @@ export default function reducer( state = initState, action ) {
   let newState = cloneDeep( state );
   const idPath = 'points.' + action.id;
   switch ( action.type ) {
+  case REHYDRATE:
+  	var incoming = action.payload.points;
+  	if(incoming) {
+		// Clear the photo URLs; local ones are transient and only valid for the current page load;
+		// they will be regenerated next time they are needed.
+		newState = {...newState, ...incoming, coverPhotoUrls: {}}
+  	}
+  	break;
   case UPDATE_SERVICE:
   case ADD_SERVICE:
   case ADD_ALERT:
@@ -119,7 +129,7 @@ export default function reducer( state = initState, action ) {
     set( newState, 'unpublishedCoverPhotos', {} );
     // Clear the photo URLs; they will be regenerated next time they are needed.
     set( newState, 'coverPhotoUrls', {} );
-break;
+    break;
   case SET_URL_FOR_POINTID:
     set( newState, 'coverPhotoUrls.' + action.pointId, action.url );
     break;

--- a/src/js/reducers/points.js
+++ b/src/js/reducers/points.js
@@ -420,9 +420,9 @@ function buildFormData( models, unpublishedCoverPhotos ) {
   ).forEach(
     model => {
       const json = model.toJSON();
-      if ( unpublishedCoverPhotos[model._id] ) {
+      if ( unpublishedCoverPhotos[model.id] ) {
         json.index = covers.length;
-        covers.push( unpublishedCoverPhotos[model._id] );
+        covers.push( unpublishedCoverPhotos[model.id] );
       }
       serialized.push( json );
     }
@@ -431,9 +431,16 @@ function buildFormData( models, unpublishedCoverPhotos ) {
 
   const formData = new FormData();
   formData.append( 'models', stringified );
-  covers.forEach( cover => {
-    formData.append( 'covers', cover, 'cover.png' );
-  } );
 
-  return formData;
+  var convertAndAppend = function(cover){
+    return base64StringToBlob(cover).then((coverPhotoBlob) => {
+      formData.append( 'covers', coverPhotoBlob, 'cover.png' );
+    });
+  };
+
+  let coverPhotoBlobs = covers.map(convertAndAppend);
+
+  return Promise.all(coverPhotoBlobs).then(() => {
+    return formData;
+  });
 }

--- a/src/js/reducers/points.js
+++ b/src/js/reducers/points.js
@@ -5,7 +5,7 @@ import { Agent, observeStore } from '../util/agent';
 import { local, remote, reset } from '../database';
 import { setSnackbar } from './notifications/snackbar';
 
-import { Point, Service, Alert, Comment, PointCollection } from 'btc-models';
+import { Point, Service, Alert, PointCollection } from 'btc-models';
 import { set, unset, bindAll, cloneDeep } from 'lodash';
 
 import { blobToBase64String, base64StringToBlob } from 'blob-util';
@@ -290,7 +290,7 @@ export function getCoverPhotoURLForPointId( pointId ) {
 
     if(state.points.coverPhotoUrls[pointId] == null) {
       if(state.points.unpublishedCoverPhotos[pointId]) {
-        return Promise.resolve().then( ( ) => { 
+        return Promise.resolve().then( ( ) => {
           base64StringToBlob(state.points.unpublishedCoverPhotos[pointId]).then((coverPhotoBlob) => { 
             let theUrl = URL.createObjectURL(coverPhotoBlob);
             dispatch( { type: SET_URL_FOR_POINTID, pointId: pointId, url: theUrl} );
@@ -378,7 +378,7 @@ export function publishPoints() {
     } );
 
     return publish.fetch().then( res => {
-      return buildFormData( publish.models );
+      return buildFormData( publish.models, points.unpublishedCoverPhotos );
     } ).then( formData => {
       return new Promise( ( resolve, reject ) => {
         const request = new XMLHttpRequest();
@@ -411,18 +411,18 @@ export function publishPoints() {
   };
 }
 
-function buildFormData( models ) {
+function buildFormData( models, unpublishedCoverPhotos ) {
   const serialized = [];
   const covers = [];
 
   models.filter(
-    model => [ Service, Alert, Comment ].some( ctr => model instanceof ctr )
+    model => [ Service, Alert ].some( ctr => model instanceof ctr )
   ).forEach(
     model => {
       const json = model.toJSON();
-      if ( model.coverBlob ) {
+      if ( unpublishedCoverPhotos[model._id] ) {
         json.index = covers.length;
-        covers.push( model.coverBlob );
+        covers.push( unpublishedCoverPhotos[model._id] );
       }
       serialized.push( json );
     }

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -74,6 +74,7 @@ let debugPrintTransformer = createTransform(
 );
 */
 
-persistStore(theStore, {transforms: [immutableTransformer/*, debugPrintTransformer*/]});
+// Don't persist the drawer state (basically the title on the nav bar).
+persistStore(theStore, {transforms: [immutableTransformer/*, debugPrintTransformer*/], blacklist: ['drawer']});
 
 export default theStore;


### PR DESCRIPTION
- Keep the unpublished photos in the Redux store instead of the points DB
- Keep a un-persisted list of the local or remote URL list for photos (only get new photo URLs on demand)
- Use JPGs instead of PNGs

- (Don't persist the drawer reducer while I'm thinking about not persisting reducers; it just keeps the label for the navigation bar and frequently causes the wrong label to show if persisted and refreshed)

#124