### PR TITLE
Eat all the touches so that we look like a desktop web browser even on mobile and we avoid all this 750ms react-tap-event-plugin nonsense (see the bottom of its readme).

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -59,10 +59,25 @@ import store from './store';
 import { NetworkStateAgent } from './reducers/network';
 import { ReplicationAgent, reloadPoints } from './reducers/points';
 
-// Eat all the touchstarts so that we look like a desktop web browser
+// Eat all the touches so that we look like a desktop web browser
 // even on mobile and we avoid all this 750ms react-tap-event-plugin
 // nonsense (see the bottom of its readme).
 document.addEventListener("touchstart", function(event) {
+    event.preventDefault();
+}, false);
+document.addEventListener("touchmove", function(event) {
+    event.preventDefault();
+}, false);
+document.addEventListener("touchend", function(event) {
+    event.preventDefault();
+}, false);
+document.addEventListener("touchenter", function(event) {
+    event.preventDefault();
+}, false);
+document.addEventListener("touchleave", function(event) {
+    event.preventDefault();
+}, false);
+document.addEventListener("touchcancel", function(event) {
     event.preventDefault();
 }, false);
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -59,7 +59,15 @@ import store from './store';
 import { NetworkStateAgent } from './reducers/network';
 import { ReplicationAgent, reloadPoints } from './reducers/points';
 
-// Fix tap events so material-ui components work
+// Eat all the touchstarts so that we look like a desktop web browser
+// even on mobile and we avoid all this 750ms react-tap-event-plugin
+// nonsense (see the bottom of its readme).
+document.addEventListener("touchstart", function(event) {
+    event.preventDefault();
+}, false);
+
+// We still need react-tap-event-plugin to translate our click events
+// into touch events to keep material-ui happy.
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();
 

--- a/src/js/containers/main.js
+++ b/src/js/containers/main.js
@@ -24,63 +24,66 @@ import '../../css/layout.css';
 // The main component is not connected. This ensures separation of concerns
 // in relation to component updates.
 export class App extends Component {
-  render() {
-    const {setShownOnboarding, settings} = this.props;
+  componentDidMount() {
+    const {setShownOnboarding, setSnackbar, settings} = this.props;
     if (!settings.shownOnboarding) {
       setShownOnboarding(true);
       history.push( `/onboarding`);
     }
 
-    const page = React.Children.only( this.props.children );
     const unsupportedMessage = 'Your browser version is not supported.';
     const delayTime = 500;
-    const tempMessage = ("Name: " + bowser.name + " Version: " + bowser.version);
-    console.log(tempMessage);
+    console.log("Browser: " + bowser.name + " Version: " + bowser.version);
+
     switch(bowser.name){
       case "Android":
         if (bowser.isUnsupportedBrowser({android: "4.4"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "iOS":
         if (bowser.isUnsupportedBrowser({ios: "9.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Chrome":
         if (bowser.isUnsupportedBrowser({chrome: "49.0"}, window.navigator.userAgent)) {
-          this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+          setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Firefox":
         if (bowser.isUnsupportedBrowser({firefox: "49.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
          break;
       case "IE":
         if (bowser.isUnsupportedBrowser({msie: "11.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Edge":
         if (bowser.isUnsupportedBrowser({edge: "13.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Safari":
         if (bowser.isUnsupportedBrowser({safari: "9.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Opera":
         if (bowser.isUnsupportedBrowser({opera: "40.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       default:
-         this.props.dispatch( setSnackbar( { message: 'We can not determine your browser version. This may affect some features.' }, delayTime ) );
+         setSnackbar( { message: 'We can not determine your browser version. This may affect some features.' }, delayTime );
         break;
     }
+  }
+
+  render() {
+    const page = React.Children.only( this.props.children );
 
     return (
       <div className='layout'>
@@ -98,6 +101,6 @@ function mapStateToProps( state ) {
   };
 }
 
-const actions = { setShownOnboarding };
+const mapDispatchToProps = { setShownOnboarding, setSnackbar };
 
-export default connect( mapStateToProps, actions )( App );
+export default connect( mapStateToProps, mapDispatchToProps )( App );


### PR DESCRIPTION
Basically if a page renders to slowly we go over an arbitrary time threshold and click again. Eating the touches fixes that so we only get click events on mobile just like on desktop.

Also move the onboarding and browser check stuff into main's componentDidMount() instead of render().
Now those things only happen when the app is launched. They may not fire if the app was backgrounded, but that's fine for what they are.
(This part will speed up page loads. I noticed it while finding why render was slower in the first place.)

https://github.com/Tour-de-Force/btc-app/issues/160