### PR TITLE
Make Cordova use WKWebView on iOS instead of the slower, deprecated UIWebView.

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -83,9 +83,16 @@
     <plugin name="cordova-plugin-network-information" spec="~1.3.1" />
     <plugin name="cordova-plugin-statusbar" version="~2.2.1" />
     <plugin name="cordova-plugin-whitelist" version="~1.3.1" />
+    <plugin name="cordova-plugin-wkwebview-engine" version="~1.1.1" />
 
     <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarBackgroundColor" value="#000000" />
     <preference name="StatusBarStyle" value="lightcontent" />
+
+	<feature name="CDVWKWebViewEngine">
+		<param name="ios-package" value="CDVWKWebViewEngine" />
+	</feature>
+
+	<preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
 
 </widget>

--- a/src/js/containers/main.js
+++ b/src/js/containers/main.js
@@ -24,63 +24,66 @@ import '../../css/layout.css';
 // The main component is not connected. This ensures separation of concerns
 // in relation to component updates.
 export class App extends Component {
-  render() {
-    const {setShownOnboarding, settings} = this.props;
+  componentDidMount() {
+    const {setShownOnboarding, setSnackbar, settings} = this.props;
     if (!settings.shownOnboarding) {
       setShownOnboarding(true);
       history.push( `/onboarding`);
     }
 
-    const page = React.Children.only( this.props.children );
     const unsupportedMessage = 'Your browser version is not supported.';
     const delayTime = 500;
-    const tempMessage = ("Name: " + bowser.name + " Version: " + bowser.version);
-    console.log(tempMessage);
+    console.log("Browser: " + bowser.name + " Version: " + bowser.version);
+
     switch(bowser.name){
       case "Android":
         if (bowser.isUnsupportedBrowser({android: "4.4"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "iOS":
         if (bowser.isUnsupportedBrowser({ios: "9.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Chrome":
         if (bowser.isUnsupportedBrowser({chrome: "49.0"}, window.navigator.userAgent)) {
-          this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+          setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Firefox":
         if (bowser.isUnsupportedBrowser({firefox: "49.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
          break;
       case "IE":
         if (bowser.isUnsupportedBrowser({msie: "11.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Edge":
         if (bowser.isUnsupportedBrowser({edge: "13.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Safari":
         if (bowser.isUnsupportedBrowser({safari: "9.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       case "Opera":
         if (bowser.isUnsupportedBrowser({opera: "40.0"}, window.navigator.userAgent)) {
-           this.props.dispatch( setSnackbar( { message: unsupportedMessage }, delayTime ) );
+           setSnackbar( { message: unsupportedMessage }, delayTime );
         }
         break;
       default:
-         this.props.dispatch( setSnackbar( { message: 'We can not determine your browser version. This may affect some features.' }, delayTime ) );
+         setSnackbar( { message: 'We can not determine your browser version. This may affect some features.' }, delayTime );
         break;
     }
+  }
+
+  render() {
+    const page = React.Children.only( this.props.children );
 
     return (
       <div className='layout'>
@@ -98,6 +101,6 @@ function mapStateToProps( state ) {
   };
 }
 
-const actions = { setShownOnboarding };
+const mapDispatchToProps = { setShownOnboarding, setSnackbar };
 
-export default connect( mapStateToProps, actions )( App );
+export default connect( mapStateToProps, mapDispatchToProps )( App );


### PR DESCRIPTION
Also, don't do work in the render method wrapping every page load.

These fixes make everything faster, which in-turn prevents the ghost touches from pages loading too slow.
The ghost touch issue is described here: https://github.com/zilverline/react-tap-event-plugin

#160