### PR TITLE
Wait for the store to actually reload before checking if we should show the onboarding panels.

### DIFF
--- a/src/js/containers/main.js
+++ b/src/js/containers/main.js
@@ -4,11 +4,9 @@ import { Paper, Dialog, FlatButton, Snackbar } from 'material-ui';
 import bowser from 'bowser';
 import { connect } from 'react-redux';
 
-import history from '../history';
 import BtcDrawer from '../containers/btc-drawer';
 import Notifications from '../containers/notifications';
 import { setSnackbar } from '../reducers/notifications/snackbar';
-import { setShownOnboarding } from '../reducers/settings';
 /*eslint-enable no-unused-vars*/
 
 import '../../css/layout.css';
@@ -25,11 +23,7 @@ import '../../css/layout.css';
 // in relation to component updates.
 export class App extends Component {
   componentDidMount() {
-    const {setShownOnboarding, setSnackbar, settings} = this.props;
-    if (!settings.shownOnboarding) {
-      setShownOnboarding(true);
-      history.push( `/onboarding`);
-    }
+    const {setSnackbar} = this.props;
 
     const unsupportedMessage = 'Your browser version is not supported.';
     const delayTime = 500;
@@ -96,11 +90,9 @@ export class App extends Component {
 }
 
 function mapStateToProps( state ) {
-  return {
-    settings: state.settings
-  };
+  return {};
 }
 
-const mapDispatchToProps = { setShownOnboarding, setSnackbar };
+const mapDispatchToProps = { setSnackbar };
 
 export default connect( mapStateToProps, mapDispatchToProps )( App );

--- a/src/js/store.js
+++ b/src/js/store.js
@@ -3,6 +3,7 @@ import notifications from './reducers/notifications';
 import points from './reducers/points';
 import tracks from './reducers/tracks';
 import settings from './reducers/settings';
+import { setShownOnboarding } from './reducers/settings';
 import network from './reducers/network';
 import map from './reducers/map';
 import filters from './reducers/filter';
@@ -13,6 +14,7 @@ import { fromJS } from 'immutable';
 import { createStore, applyMiddleware, compose, combineReducers } from 'redux';
 import { persistStore, autoRehydrate, createTransform } from 'redux-persist'
 import thunk from 'redux-thunk';
+import history from './history';
 
 const devTools = typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f;
 
@@ -75,6 +77,12 @@ let debugPrintTransformer = createTransform(
 */
 
 // Don't persist the drawer state (basically the title on the nav bar).
-persistStore(theStore, {transforms: [immutableTransformer/*, debugPrintTransformer*/], blacklist: ['drawer']});
+persistStore(theStore, {transforms: [immutableTransformer/*, debugPrintTransformer*/], blacklist: ['drawer', 'map', 'network', 'notifications']}, () => {
+  // This is called once the store is loaded.
+  if (!theStore.getState().settings.shownOnboarding) {
+    theStore.dispatch(setShownOnboarding(true));
+    history.push(`/onboarding`);
+  }
+});
 
 export default theStore;


### PR DESCRIPTION
This fixes a race condition where sometimes the boolean indicating that the panels have already been shown hadn't reloaded before it was checked.

Also, don't persist Map, Network, and Notification reducers that have no need to be persisted while I'm here.

#185